### PR TITLE
GUI deadlock, maven build fix, better version comparison to detect the need of update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>ttorrent</artifactId>
             <version>1.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.0.3</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <build>

--- a/src/main/java/com/xmage/launcher/DownloadTask.java
+++ b/src/main/java/com/xmage/launcher/DownloadTask.java
@@ -11,7 +11,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URL;
+import java.util.List;
+
 import javax.swing.JProgressBar;
+import javax.swing.JTextArea;
 import javax.swing.SwingWorker;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -20,22 +23,41 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.xmage.launcher.DownloadTask.Progress;
 
 /**
  *
  * @author BetaSteward
  */
-public abstract class DownloadTask extends SwingWorker<Void, Void> {
+public abstract class DownloadTask extends SwingWorker<Void, Progress> {
+
+    public static class Progress {
+        String text;
+        Integer perc;
+
+        public Progress(String text) {
+            this.text = text;
+            perc = -1;
+        }
+
+        public Progress(Integer perc) {
+            this.perc = perc;
+            text = null;
+        }
+
+    }
 
     private static final int BUFFER_SIZE = 4096;
     private static final Logger logger = LoggerFactory.getLogger(DownloadTask.class);    
     
     private final JProgressBar progressBar;
-    
-    public DownloadTask(JProgressBar progressBar) {
+    private final JTextArea textArea;
+
+    public DownloadTask(JProgressBar progressBar, JTextArea textArea) {
         this.progressBar = progressBar;
+        this.textArea = textArea;
     }
-        
+
     protected boolean download(URL downloadURL, String saveDirectory, String cookies) throws IOException {
         try {
             Downloader dl = new Downloader();
@@ -50,47 +72,66 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
             int count;
             long total = 0;
             long size = dl.getSize();
-            progressBar.setValue(0);
+            publish(0);
             while ((count = in.read(data, 0, BUFFER_SIZE)) != -1) {
                 fout.write(data, 0, count);
                 total += count;
-                progressBar.setValue((int)((total * 100)/size));
+                publish((int) (total * 100 / size));
             }
             fout.close();
             dl.disconnect();
             return true;
-        }
-        catch (IOException ex) {
-            progressBar.setValue(0);
-            this.cancel(true);
+        } catch (IOException ex) {
+            publish(0);
+            cancel(true);
             logger.error("Error: ", ex);
             return false;
+        }
+    }
+
+    protected void publish(int perc) {
+        publish(new Progress(perc));
+    }
+
+    protected void publish(String text) {
+        publish(new Progress(text));
+    }
+
+    @Override
+    protected void process(List<Progress> chunks) {
+        for (Progress chunk : chunks) {
+            if (chunk.perc >= 0) {
+                progressBar.setValue(chunk.perc);
+            }
+            if (chunk.text != null) {
+                textArea.append(chunk.text);
+            }
         }
     }
 
     public void torrent(File from, File to) throws IOException {
         // First, instantiate the Client object.
         SharedTorrent torrent = SharedTorrent.fromFile(from, to);
-        
+
         Client client = new Client(InetAddress.getLocalHost(), torrent);
 
-        client.setMaxDownloadRate((double)Config.getTorrentDownRate());
-        client.setMaxUploadRate((double)Config.getTorrentUpRate());
+        client.setMaxDownloadRate((double) Config.getTorrentDownRate());
+        client.setMaxUploadRate((double) Config.getTorrentUpRate());
 
         client.download();
-        
+
         while (!torrent.isComplete()) {
-            progressBar.setValue((int)torrent.getCompletion());
+            publish((int) torrent.getCompletion());
         }
 
     }
-    
+
     protected void extract(File from, File to) throws IOException {
-        
+
         TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(from)));
 
-        //first calculate the aggregate size for displaying progress
-        progressBar.setValue(0);
+        // first calculate the aggregate size for displaying progress
+        publish(0);
         TarArchiveEntry tarEntry;
         long size = 0;
         while ((tarEntry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
@@ -98,7 +139,7 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
         }
         tarIn.close();
 
-        //now write out the files
+        // now write out the files
         long total = 0;
         tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(from)));
         while ((tarEntry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
@@ -107,7 +148,7 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
             if (tarEntry.isDirectory()) {
                 destPath.mkdirs();
             } else {
-                destPath.createNewFile();                
+                destPath.createNewFile();
                 byte data[] = new byte[BUFFER_SIZE];
                 BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(destPath), BUFFER_SIZE);
                 int count;
@@ -116,14 +157,14 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
                 }
                 out.close();
                 total += tarEntry.getSize();
-                progressBar.setValue((int)((total * 100)/size));
+                publish((int) (total * 100 / size));
             }
             setFilePermissions(destPath, mode);
         }
         tarIn.close();
-        
+
     }
-    
+
     private static final int OWNER_READ = 256;
     private static final int OWNER_WRITE = 128;
     private static final int OWNER_EXEC = 64;
@@ -131,51 +172,45 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
     private static final int EVERYONE_READ = 4;
     private static final int EVERYONE_WRITE = 2;
     private static final int EVERYONE_EXEC = 1;
-    
-    private void setFilePermissions(File file, int mode)  {
+
+    private void setFilePermissions(File file, int mode) {
         if ((mode & EVERYONE_READ) == EVERYONE_READ) {
             file.setReadable(true, false);
-        }
-        else if ((mode & OWNER_READ) == OWNER_READ) {
+        } else if ((mode & OWNER_READ) == OWNER_READ) {
             file.setReadable(true, true);
-        }
-        else {
+        } else {
             file.setReadable(false, false);
         }
         if ((mode & EVERYONE_WRITE) == EVERYONE_WRITE) {
             file.setWritable(true, false);
-        }
-        else if ((mode & OWNER_WRITE) == OWNER_WRITE) {
+        } else if ((mode & OWNER_WRITE) == OWNER_WRITE) {
             file.setWritable(true, true);
-        }
-        else {
+        } else {
             file.setWritable(false, false);
         }
         if ((mode & EVERYONE_EXEC) == EVERYONE_EXEC) {
             file.setExecutable(true, false);
-        }
-        else if ((mode & OWNER_EXEC) == OWNER_EXEC) {
+        } else if ((mode & OWNER_EXEC) == OWNER_EXEC) {
             file.setExecutable(true, true);
-        }
-        else {
+        } else {
             file.setExecutable(false, false);
         }
     }
-    
+
     protected void unzip(File from, File to) throws IOException {
-        
+
         ZipArchiveInputStream zipIn = new ZipArchiveInputStream(new FileInputStream(from));
-        
-        //first calculate the aggregate size for displaying progress
-        progressBar.setValue(0);
+
+        // first calculate the aggregate size for displaying progress
+        publish(0);
         ZipArchiveEntry zipEntry;
         long size = 0;
-        while ((zipEntry = (ZipArchiveEntry)zipIn.getNextEntry()) != null) {
+        while ((zipEntry = (ZipArchiveEntry) zipIn.getNextEntry()) != null) {
             size += zipEntry.getSize();
         }
         zipIn.close();
-        
-        //now write out the files
+
+        // now write out the files
         long total = 0;
         zipIn = new ZipArchiveInputStream(new FileInputStream(from));
         while ((zipEntry = (ZipArchiveEntry) zipIn.getNextEntry()) != null) {
@@ -183,7 +218,7 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
             if (zipEntry.isDirectory()) {
                 destPath.mkdirs();
             } else {
-                File pathFile = new File(destPath.getAbsolutePath().substring(0,destPath.getAbsolutePath().lastIndexOf(File.separator)));
+                File pathFile = new File(destPath.getAbsolutePath().substring(0, destPath.getAbsolutePath().lastIndexOf(File.separator)));
                 pathFile.mkdirs();
                 destPath.createNewFile();
                 byte data[] = new byte[BUFFER_SIZE];
@@ -194,7 +229,7 @@ public abstract class DownloadTask extends SwingWorker<Void, Void> {
                 }
                 out.close();
                 total += zipEntry.getSize();
-                progressBar.setValue((int)((total * 100)/size));
+                publish((int) (total * 100 / size));
             }
         }
         zipIn.close();

--- a/src/main/java/com/xmage/launcher/SettingsDialog.java
+++ b/src/main/java/com/xmage/launcher/SettingsDialog.java
@@ -50,7 +50,8 @@ public class SettingsDialog extends JDialog {
 
         setTitle("XMage Launcher Settings");
         setModalityType(ModalityType.APPLICATION_MODAL);
-	setSize(500, 300);
+        pack();
+        setSize(500, 300);
         setBackground(Color.gray);
         setLocationRelativeTo(null);
         this.addWindowListener(new WindowAdapter() {
@@ -60,7 +61,7 @@ public class SettingsDialog extends JDialog {
             }
         });
                 
-	setLayout(new BorderLayout());
+        setLayout(new BorderLayout());
 
         GridBagLayout layout;
         GridBagConstraints constraints;
@@ -186,7 +187,7 @@ public class SettingsDialog extends JDialog {
         spnDownRate = new JSpinner(model);
         constraints.gridwidth = 1;
         constraints.anchor = GridBagConstraints.WEST;
-       panel3.add(spnDownRate, constraints);
+        panel3.add(spnDownRate, constraints);
         
         constraints.gridwidth = GridBagConstraints.REMAINDER;
         panel3.add(Box.createHorizontalBox(), constraints);

--- a/src/main/java/com/xmage/launcher/StreamGobbler.java
+++ b/src/main/java/com/xmage/launcher/StreamGobbler.java
@@ -4,7 +4,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
 import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
 import org.slf4j.LoggerFactory;
 
 /**
@@ -12,36 +15,40 @@ import org.slf4j.LoggerFactory;
  * 
  * @author BetaSteward
  */
-public class StreamGobbler extends Thread
-{
+public class StreamGobbler extends Thread {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(StreamGobbler.class);
-    
+
     private final InputStream is;
     private final JTextArea text;
 
-    public StreamGobbler(InputStream is, JTextArea text)
-    {
+    public StreamGobbler(InputStream is, JTextArea text) {
         this.is = is;
         this.text = text;
     }
 
     @Override
-    public void run()
-    {
-        try
-        {
+    public void run() {
+        try {
             InputStreamReader isr = new InputStreamReader(is);
             BufferedReader br = new BufferedReader(isr);
             String line;
-            while ( (line = br.readLine()) != null)
-            {
-                text.append(line + "\n"); // JTextArea.append is thread safe
+            while ((line = br.readLine()) != null) {
+                appendLine(line);
             }
-        }
-        catch (IOException ex)
-        {
-            text.append(ex.toString()); // note below
+        } catch (IOException ex) {
+            appendLine(ex.toString()); // note below
             logger.error("Error processing stream", ex);
         }
+    }
+
+    private void appendLine(final String line) {
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                text.append(line + "\n"); // JTextArea.append is NOT thread safe, see
+                                          // http://stackoverflow.com/questions/8436949/thread-safety-of-jtextarea-append
+            }
+        });
     }
 }

--- a/src/main/java/com/xmage/launcher/Utilities.java
+++ b/src/main/java/com/xmage/launcher/Utilities.java
@@ -108,7 +108,7 @@ public class Utilities {
 
     public static Process launchServerProcess() {
 
-        return launchProcess("mage.server.ServerMain", Config.getServerJavaOpts(), "mage-server");
+        return launchProcess("mage.server.Main", Config.getServerJavaOpts(), "mage-server");
 
     }
 

--- a/src/main/java/com/xmage/launcher/XMageLauncher.java
+++ b/src/main/java/com/xmage/launcher/XMageLauncher.java
@@ -45,6 +45,7 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.border.Border;
 import javax.swing.text.DefaultCaret;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -603,7 +604,9 @@ public class XMageLauncher implements Runnable {
                             textArea.append(messages.getString("xmage.launcher.installed") + launcherInstalledVersion + "\n");
                             textArea.append(messages.getString("xmage.launcher.available") + launcherAvailableVersion + "\n");
                             removeOldLauncherFiles(launcherFolder, launcherInstalledVersion);
-                            if (!launcherAvailableVersion.equals(launcherInstalledVersion)) {
+                            DefaultArtifactVersion launcherInstalledVersionArtifact = new DefaultArtifactVersion(launcherInstalledVersion);
+                            DefaultArtifactVersion launcherAvailableVersionArtifact = new DefaultArtifactVersion(launcherAvailableVersion);
+                            if (launcherAvailableVersionArtifact.compareTo(launcherInstalledVersionArtifact) > 0) {
                                 String launcherMessage = "";
                                 String launcherTitle = "";
                                 textArea.append(messages.getString("xmage.launcher.new") + "\n");


### PR DESCRIPTION
On two my machines there's a deadlock happening on launch resulting in an empty gray window. Not every time, though, so looks like a race condition. May be platform specific, my config: `Intel Core i7-2600, 32Gb RAM, NVIDIA GeForce 770 GTX driver v361.28, Debian Stretch GNU/Linux amd64, Awesome WM 3.5.6, kernel v4.3`

I know about issues with OpenJDK+AwesomeWM, already have:
```
_JAVA_AWT_WM_NONREPARENTING=1
AWT_TOOLKIT=MToolkit
_JAVA_OPTIONS="-Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dsun.java2d.opengl=true" (removing the last option doesn't help)
wmname LG3D
```
Turning these on and off doesn't change much. Sometimes the launcher works but after restart it doesn't. Pure luck i.e. Tried Java 7 and 8, tried different Look'n'Feel Swing options. Hence decided to dig the source and fix it once and for all. Probably succeeded.

The main issue is incorrect usage of SwingWorker and believing that JTextArea#append is thread safe (it's not [since Java 7](http://stackoverflow.com/questions/8436949/thread-safety-of-jtextarea-append)). I refactored DownloadTask to use progress/publish method so it prints messages and updates the progress bar from the EDT.