### PR TITLE
Fix settings dialog and make launcher update less destructive

### DIFF
--- a/src/main/java/com/xmage/launcher/SettingsDialog.java
+++ b/src/main/java/com/xmage/launcher/SettingsDialog.java
@@ -122,7 +122,7 @@ public class SettingsDialog extends JDialog {
         constraints.fill = GridBagConstraints.NONE;
         panel1.add(label, constraints);
 
-        SpinnerModel guiSizemodel = new SpinnerNumberModel(Config.getTorrentUpRate(), 10, 50, 1);
+        SpinnerModel guiSizemodel = new SpinnerNumberModel(Config.getGuiSize(), 10, 50, 1);
         spnGuiSize = new JSpinner(guiSizemodel);
         spnGuiSize.setValue(Config.getGuiSize());
 //        Component mySpinnerEditor = spnGuiSize.getEditor();

--- a/src/main/java/com/xmage/launcher/XMageLauncher.java
+++ b/src/main/java/com/xmage/launcher/XMageLauncher.java
@@ -635,7 +635,6 @@ public class XMageLauncher implements Runnable {
                 String launcherInstalledVersion = Config.getVersion();
                 publish(messages.getString("xmage.launcher.installed") + launcherInstalledVersion + "\n");
                 publish(messages.getString("xmage.launcher.available") + launcherAvailableVersion + "\n");
-                removeOldLauncherFiles(launcherFolder, launcherInstalledVersion);
                 DefaultArtifactVersion launcherInstalledVersionArtifact = new DefaultArtifactVersion(launcherInstalledVersion);
                 DefaultArtifactVersion launcherAvailableVersionArtifact = new DefaultArtifactVersion(launcherAvailableVersion);
                 if (launcherAvailableVersionArtifact.compareTo(launcherInstalledVersionArtifact) > 0) {
@@ -654,6 +653,7 @@ public class XMageLauncher implements Runnable {
 
                         download(launcher, path.getAbsolutePath(), "");
 
+                        removeOldLauncherFiles(launcherFolder, launcherInstalledVersion);
                         File from = new File(path.getAbsolutePath() + File.separator + "xmage.dl");
                         publish(messages.getString("xmage.launcher.installing"));
                         File to = new File(launcherFolder, "XMageLauncher-" + launcherAvailableVersion + ".jar");


### PR DESCRIPTION
The GUI size spinner code took its value from the torrent uprate, probably a copypaste issue. The launcher jar was removed prior to confirming its update, if user declines it, they're left without any launcher.