### PR TITLE
UTF-8 encoding for downloading all card images

### DIFF
--- a/src/main/java/com/xmage/launcher/Config.java
+++ b/src/main/java/com/xmage/launcher/Config.java
@@ -26,7 +26,7 @@ public class Config {
     private static final Properties props = new Properties();
     private static final String DEFAULT_URL = "http://xmage.de/xmage";
     private static final String BETA_URL = "http://rkfg.me/xmage";
-    private static final String DEFAULT_CLIENT_JAVA_OPTS = "-Xms256m -Xmx512m -XX:MaxPermSize=384m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled";
+    private static final String DEFAULT_CLIENT_JAVA_OPTS = "-Xms256m -Xmx512m -XX:MaxPermSize=384m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Dfile.encoding=UTF-8";
     private static final String DEFAULT_SERVER_JAVA_OPTS = "-Xms256M -Xmx1G -XX:MaxPermSize=384m";
 
     private static String version = "";


### PR DESCRIPTION
The launcher's default java options now include UTF-8 encoding for the client, so it's capable of downloading all the card images with special characters, like for example the Tenth Edition foils that are marked with ★ or * in their card number field.

The XMage default startclient.bat and startServer.bat files already use this UTF-8 java option, it's just the launcher that's missing it.

UTF-8 could also be added to the launcher's server java options, but I don't know any reason why that would be needed.

Tenth Edition looks like this without the UTF-8 option enabled:
![2022-08-03 03_45_36-XMage  Client_ 1 4 50-V2 (build_ 2022-08-01 02_34)  Server_ _not connected_](https://user-images.githubusercontent.com/13901691/182501974-9356c68a-61e4-4901-b3f4-04d3a58af336.png)

After enabling UTF-8 and redownloading Tenth Edition images:
![2022-08-03 03_56_15-XMage  Client_ 1 4 51-V4-beta8 (build_ 2022-07-29 20_29)  Server_ _not connected](https://user-images.githubusercontent.com/13901691/182502052-468befba-ae7f-4d22-a693-103f0e846b76.png)

