### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,17 +13,17 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.9</version>
+            <version>1.27.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20151123</version>
+            <version>20250517</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.33</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>2.0.17</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Some of the current dependencies have high and medium severity vulnerabilities, I believe dependabot also identified a few of these too. This PR updates the vulnerable ones to non-vulnerable versions. I'd actually been using a version with these changes along with the latest commits in this repo as my daily launcher for the past week and I've not had any issues. I also ran back through the testing from #30 with no changes noted.

Table below showing the vulnerabilities in the current version:
```
╭─────────────────────────────────────┬──────┬───────────┬─────────────────────────────────────┬──────────┬──────────────────╮
│ OSV URL                             │ CVSS │ ECOSYSTEM │ PACKAGE                             │ VERSION  │ SOURCE           │
├─────────────────────────────────────┼──────┼───────────┼─────────────────────────────────────┼──────────┼──────────────────┤
│ https://osv.dev/GHSA-2qrg-x229-3v8q │ 9.8  │ Maven     │ log4j:log4j                         │ 1.2.17   │ Launcher/pom.xml │
│ https://osv.dev/GHSA-65fg-84f6-3jq3 │ 9.8  │ Maven     │ log4j:log4j                         │ 1.2.17   │ Launcher/pom.xml │
│ https://osv.dev/GHSA-f7vh-qwp3-x37m │ 9.8  │ Maven     │ log4j:log4j                         │ 1.2.17   │ Launcher/pom.xml │
│ https://osv.dev/GHSA-fp5r-v3w9-4333 │ 7.5  │ Maven     │ log4j:log4j                         │ 1.2.17   │ Launcher/pom.xml │
│ https://osv.dev/GHSA-w9p3-5cr8-m3jj │ 8.8  │ Maven     │ log4j:log4j                         │ 1.2.17   │ Launcher/pom.xml │
│ https://osv.dev/GHSA-4g9r-vxhx-9pgx │ 5.9  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-7hfm-57qf-j43q │ 7.5  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-crv7-7245-f45f │ 7.5  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-hrmr-f5m6-m9pq │ 5.5  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-mc84-pj99-q6hh │ 7.5  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-xqfj-vm6h-2x34 │ 7.5  │ Maven     │ org.apache.commons:commons-compress │ 1.9      │ Launcher/pom.xml │
│ https://osv.dev/GHSA-3vqj-43w4-2q58 │ 7.5  │ Maven     │ org.json:json                       │ 20151123 │ Launcher/pom.xml │
│ https://osv.dev/GHSA-4jq9-2xhw-jpx7 │      │ Maven     │ org.json:json                       │ 20151123 │ Launcher/pom.xml │
╰─────────────────────────────────────┴──────┴───────────┴─────────────────────────────────────┴──────────┴──────────────────╯
```

No vulnerabilities are identified after a rescan with the changes in this PR.