### PR TITLE
Update commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Updating commons-compress to latest version to resolve a vulnerability.

Tested on an existing install with no issues.

Also ran as a "fresh" install, using only the XMageLauncher.jar. Both XMage and XMage Java were both downloaded and extracted successfully. 